### PR TITLE
use file.path() instead of paste0()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,4 +44,4 @@ VignetteBuilder:
 Encoding: UTF-8
 Language: en-US
 LazyData: true
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2

--- a/R/gi_write_gitignore.R
+++ b/R/gi_write_gitignore.R
@@ -11,7 +11,7 @@
 #'
 #' @examples
 #' \donttest{
-#' f <- paste0(tempdir(), "/.gitignore")
+#' f <- file.path(tempdir(), ".gitignore")
 #' new_lines <- gi_fetch_templates("r")
 #' gi_write_gitignore(new_lines, f)
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -77,7 +77,7 @@ gi_fetch_templates(c("java", "c++"))
 By default, templates are copied into the clipboard. It is also possible to modify a `.gitignore` file using the `gi_write_gitignore()` function.
 
 ```{r, eval=FALSE}
-f <- paste0(tempdir(), "/.gitignore")
+f <- file.path(tempdir(), ".gitignore")
 new_lines <- gi_fetch_templates("r")
 gi_write_gitignore(fetched_template = new_lines, gitignore_file = f)
 ```

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Show the first 25 templates returned by `gi_available_templates()`.
 library(gitignore)
 
 head(gi_available_templates(), 25)
-#>  [1] "1c"                   "1c-bitrix"            "actionscript"        
-#>  [4] "ada"                  "adobe"                "advancedinstaller"   
-#>  [7] "adventuregamestudio"  "a-frame"              "agda"                
+#>  [1] "1c"                   "1c-bitrix"            "a-frame"             
+#>  [4] "actionscript"         "ada"                  "adobe"               
+#>  [7] "advancedinstaller"    "adventuregamestudio"  "agda"                
 #> [10] "al"                   "alteraquartusii"      "altium"              
 #> [13] "android"              "androidstudio"        "angular"             
 #> [16] "anjuta"               "ansible"              "apachecordova"       
@@ -97,6 +97,7 @@ gi_fetch_templates("R")
 
 # Session Data files
 .RData
+.RDataTmp
 
 # User-specific files
 .Ruserdata
@@ -209,7 +210,7 @@ By default, templates are copied into the clipboard. It is also possible
 to modify a `.gitignore` file using the `gi_write_gitignore()` function.
 
 ``` r
-f <- paste0(tempdir(), "/.gitignore")
+f <- file.path(tempdir(), ".gitignore")
 new_lines <- gi_fetch_templates("r")
 gi_write_gitignore(fetched_template = new_lines, gitignore_file = f)
 ```
@@ -233,7 +234,6 @@ Code of
 Conduct](https://docs.ropensci.org/gitignore/CODE_OF_CONDUCT.html). By
 [contributing to this
 project](https://docs.ropensci.org/gitignore/CONTRIBUTING.html), you
-agree to abide by its
-terms.
+agree to abide by its terms.
 
 [![ropensci\_footer](https://ropensci.org/public_images/ropensci_footer.png)](https://ropensci.org)

--- a/man/gi_fetch_templates.Rd
+++ b/man/gi_fetch_templates.Rd
@@ -4,8 +4,12 @@
 \alias{gi_fetch_templates}
 \title{Fetch gitignore template(s) from gitignore.io}
 \usage{
-gi_fetch_templates(template_name, copy_to_clipboard = FALSE,
-  append_gitignore = FALSE, gitignore_file = here::here(".gitignore"))
+gi_fetch_templates(
+  template_name,
+  copy_to_clipboard = FALSE,
+  append_gitignore = FALSE,
+  gitignore_file = here::here(".gitignore")
+)
 }
 \arguments{
 \item{template_name}{A character vector with values included in

--- a/man/gi_write_gitignore.Rd
+++ b/man/gi_write_gitignore.Rd
@@ -4,8 +4,7 @@
 \alias{gi_write_gitignore}
 \title{Append or create a .gitignore file}
 \usage{
-gi_write_gitignore(fetched_template,
-  gitignore_file = here::here(".gitignore"))
+gi_write_gitignore(fetched_template, gitignore_file = here::here(".gitignore"))
 }
 \arguments{
 \item{fetched_template}{Template(s) returned by `gi_fetch_templates()`.}
@@ -20,7 +19,7 @@ Use the returned template(s) to append the existing .gitignore file.
 }
 \examples{
 \donttest{
-f <- paste0(tempdir(), "/.gitignore")
+f <- file.path(tempdir(), ".gitignore")
 new_lines <- gi_fetch_templates("r")
 gi_write_gitignore(new_lines, f)
 

--- a/man/gitignore-package.Rd
+++ b/man/gitignore-package.Rd
@@ -13,18 +13,19 @@ Simple interface to query gitignore.io to fetch
 \seealso{
 Useful links:
 \itemize{
+  \item \url{https://docs.ropensci.org/gitignore}
   \item \url{https://github.com/ropensci/gitignore}
   \item Report bugs at \url{https://github.com/ropensci/gitignore/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Philippe Massicotte \email{pmassicotte@hotmail.com} (0000-0002-5919-4116)
+\strong{Maintainer}: Philippe Massicotte \email{pmassicotte@hotmail.com} (\href{https://orcid.org/0000-0002-5919-4116}{ORCID})
 
 Other contributors:
 \itemize{
   \item Amanda Dobbyn \email{amanda.e.dobbyn@gmail.com} [reviewer]
-  \item Mauro Lepore \email{maurolepore@gmail.com} (0000-0002-1986-7988) [reviewer]
+  \item Mauro Lepore \email{maurolepore@gmail.com} (\href{https://orcid.org/0000-0002-1986-7988}{ORCID}) [reviewer]
 }
 
 }

--- a/tests/testthat/test_gi_fetch_templates.R
+++ b/tests/testthat/test_gi_fetch_templates.R
@@ -32,7 +32,7 @@ test_that("Template can be copied in the clipboard", {
 })
 
 test_that("A non existing .gitignore file can be created", {
-  f <- paste0(tempdir(), "/.gitignore")
+  f <- file.path(tempdir(), ".gitignore")
   unlist(f)
   file.create(f)
 

--- a/tests/testthat/test_gi_write_gitignore.R
+++ b/tests/testthat/test_gi_write_gitignore.R
@@ -1,5 +1,5 @@
 test_that("no change in the gitignore file", {
-  f <- paste0(tempdir(), "/.gitignore")
+  f <- file.path(tempdir(), ".gitignore")
   file.create(f)
 
   new_lines <- gi_fetch_templates("r")
@@ -14,7 +14,7 @@ test_that("no change in the gitignore file", {
 })
 
 test_that(".gitignore file can not be found", {
-  f <- paste0(tempdir(), "/.gitignore")
+  f <- file.path(tempdir(), ".gitignore")
   unlink(f)
 
   new_lines <- gi_fetch_templates("r")

--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -60,7 +60,7 @@ gi_fetch_templates(c("R"), append_gitignore = TRUE)
 It is also possible to specify the `.gitignore` file to be modified by specifying the `gitignore_file` argument.
 
 ```{r, message=TRUE}
-f <- paste0(tempdir(), "/.gitignore")
+f <- file.path(tempdir(), ".gitignore")
 
 file.create(f)
 


### PR DESCRIPTION
This PR replaces the `paste0()` with `file.path()` where appropriate. 

`file.path()` is generally preferred, because it sets the correct path separator depending on the platform. It is also faster, but this shouldn't matter much here, though. 